### PR TITLE
fix: make table display a bit better on smaller screens

### DIFF
--- a/assets/scss/template.scss
+++ b/assets/scss/template.scss
@@ -124,7 +124,6 @@ ul.network-icon .big-icon {
 table.voting-chart {
   thead {
     background-color: #fff;
-
   }
 
   tr.pass {
@@ -153,12 +152,17 @@ table.voting-chart {
   }
 }
 
-
 table.voting-chart {
   thead {
     position: sticky;
     top: 0;
     z-index: 2;
+  }
+  th:not(:first-child) {
+    @media (max-width: 801px) {
+      text-orientation: mixed;
+      writing-mode: vertical-rl;
+    }
   }
   tr.pulled {
     text-decoration: line-through;


### PR DESCRIPTION
This isn't the best solution, but having a sticky table header limits the options for overflow & likely requires a js solution to synchronize scrolling & sizing between header & body columns. Maybe this is a decent way to enable mobile users to see how Ward 5 has voted (they're getting cut off on some mobile screens atm)